### PR TITLE
Fix: Remove log on passed settings object to prevent it from being overwritten

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const AgentKeepAlive = require('agentkeepalive');
 module.exports = function ESClient(config) {
 
   const log = config && config.log;
+  delete config.log;
 
   function LogConstructor() {
     // info tends to log 'Request complete' messages which we usually don't care about

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ const AgentKeepAlive = require('agentkeepalive');
 
 module.exports = function ESClient(config) {
 
-  const log = config && config.log;
+  // Shallow clone since we're modifying config
+  config = _.clone(config || {});
+
+  const log = config.log;
   delete config.log;
 
   function LogConstructor() {
@@ -30,7 +33,7 @@ module.exports = function ESClient(config) {
       return new AgentKeepAlive(connection.makeAgentConfig(conf));
     },
     log: log && LogConstructor
-  }, config || {});
+  }, config);
 
   return new elasticsearch.Client(config);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-esclient",
   "description": "Elasticsearch client used within Enrise projects and module's",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/test/esclient.spec.js
+++ b/test/esclient.spec.js
@@ -57,11 +57,13 @@ describe('ESClient', () => {
       other: 'custom settings'
     };
     new EnriseClient(config); // eslint-disable-line no-new
-    expect(ElasticsearchClient).to.have.been.calledWith({
+    const args = ElasticsearchClient.args[0][0];
+
+    expect(_.omit(args, 'log')).to.deep.equal({
       createNodeAgent: config.createNodeAgent,
-      log: config.log,
       other: 'custom settings'
     });
+    chai.assert.isFunction(args.log);
   });
 
   it('correctly calls the AgentKeepAlive', () => {
@@ -115,6 +117,19 @@ describe('ESClient', () => {
         response: 'body'
       },
       statusCode: 200
+    });
+  });
+
+  it('does not modify the passed config object', () => {
+    const config = {
+      foo: 'bar',
+      log: {}
+    };
+
+    new EnriseClient(config); // eslint-disable-line no-new
+    expect(config).to.deep.equal({
+      foo: 'bar',
+      log: {}
     });
   });
 });


### PR DESCRIPTION
### Context
There is a bug that incorrectly passes the log constructor to the elasticsearch client.

### What has been done
- Remove log on passed settings object to prevent it from being overwritten