### PR TITLE
Fix logger method binding in LogConstructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,10 @@ module.exports = function ESClient(config) {
 
   function LogConstructor() {
     // info tends to log 'Request complete' messages which we usually don't care about
-    this.info = log.debug;
-    this.debug = log.debug;
-    this.error = log.error;
-    this.warning = log.warn;
+    this.info = log.debug.bind(log);
+    this.debug = log.debug.bind(log);
+    this.error = log.error.bind(log);
+    this.warning = log.warn.bind(log);
 
     // this can not be an arrow function because we require access to the arguments.
     this.trace = function () {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-esclient",
   "description": "Elasticsearch client used within Enrise projects and module's",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/test/esclient.spec.js
+++ b/test/esclient.spec.js
@@ -19,9 +19,9 @@ describe('ESClient', () => {
       foo: 'bar'
     });
     logger = {
-      debug: 'DEBUG',
-      error: 'ERROR',
-      warn: 'WARN',
+      debug: sinon.stub(),
+      error: sinon.stub(),
+      warn: sinon.stub(),
       verbose: sinon.stub()
     };
     agentkeepalive = sinon.stub();
@@ -93,17 +93,18 @@ describe('ESClient', () => {
 
     const log = new LogConstructor(); // eslint-disable-line no-new
 
+    chai.assert.isFunction(log.info);
+    chai.assert.isFunction(log.debug);
+    chai.assert.isFunction(log.error);
+    chai.assert.isFunction(log.warning);
     chai.assert.isFunction(log.trace);
     chai.assert.isFunction(log.close);
 
-    log.trace('POST', {url: 'local:9200', agent: 'elasticsearch'}, {request: 'body'}, {response: 'body'}, 200);
+    // Verify methods delegate to the original logger (binding must be preserved)
+    log.debug('test-debug');
+    expect(logger.debug).to.have.been.calledWith('test-debug');
 
-    expect(_.omit(log, 'trace', 'close')).to.deep.equal({
-      info: 'DEBUG',
-      debug: 'DEBUG',
-      error: 'ERROR',
-      warning: 'WARN'
-    });
+    log.trace('POST', {url: 'local:9200', agent: 'elasticsearch'}, {request: 'body'}, {response: 'body'}, 200);
 
     expect(logger.verbose).to.have.been.calledWith({
       httpMethod: 'POST',


### PR DESCRIPTION
## Summary

- Bind `log.debug`, `log.error`, `log.warn` to their parent object in `LogConstructor` so that real winston logger instances (and sinon stubs) retain `this` context when called by the elasticsearch client
- Update test logger mock from plain string values to `sinon.stub()` so that binding can be verified by assertion
- Add explicit `isFunction` assertions for all `LogConstructor` methods

## Test plan

- [x] `npm test` passes (lint + coverage)