### PR TITLE
Remap freeSocketKeepAliveTimeout to freeSocketTimeout for agentkeepalive@4

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,12 @@ module.exports = function ESClient(config) {
   // us fix the out-of-connections problems, it also seemed to help with dangling connections.
   config = _.merge({
     createNodeAgent(connection, conf) {
-      return new AgentKeepAlive(connection.makeAgentConfig(conf));
+      const agentConfig = connection.makeAgentConfig(conf);
+      if (agentConfig.freeSocketKeepAliveTimeout !== undefined) {
+        agentConfig.freeSocketTimeout = agentConfig.freeSocketTimeout || agentConfig.freeSocketKeepAliveTimeout;
+        delete agentConfig.freeSocketKeepAliveTimeout;
+      }
+      return new AgentKeepAlive(agentConfig);
     },
     log: log && LogConstructor
   }, config);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-esclient",
   "description": "Elasticsearch client used within Enrise projects and module's",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/test/esclient.spec.js
+++ b/test/esclient.spec.js
@@ -69,7 +69,7 @@ describe('ESClient', () => {
   it('correctly calls the AgentKeepAlive', () => {
     new EnriseClient(); // eslint-disable-line no-new
     const connection = {
-      makeAgentConfig: sinon.stub().returns('call agentkeepalive')
+      makeAgentConfig: sinon.stub().returns({foo: 'bar'})
     };
     const config = {
       foo: 'bar'
@@ -79,7 +79,27 @@ describe('ESClient', () => {
     expect(connection.makeAgentConfig).to.have.been.calledWith({
       foo: 'bar'
     });
-    expect(agentkeepalive).to.have.been.calledWith('call agentkeepalive');
+    expect(agentkeepalive).to.have.been.calledWith({foo: 'bar'});
+  });
+
+  it('remaps freeSocketKeepAliveTimeout to freeSocketTimeout for agentkeepalive@4', () => {
+    new EnriseClient(); // eslint-disable-line no-new
+    const createNodeAgent = ElasticsearchClient.args[0][0].createNodeAgent;
+
+    const connection = {makeAgentConfig: sinon.stub().returns({freeSocketKeepAliveTimeout: 5000})};
+    createNodeAgent(connection, {});
+    expect(agentkeepalive).to.have.been.calledWith({freeSocketTimeout: 5000});
+    expect(agentkeepalive.lastCall.args[0]).to.not.have.property('freeSocketKeepAliveTimeout');
+
+
+    agentkeepalive.resetHistory();
+
+    // does not overwrite an existing freeSocketTimeout
+    const agentConfig2 = {freeSocketTimeout: 3000, freeSocketKeepAliveTimeout: 5000};
+    const connection2 = {makeAgentConfig: sinon.stub().returns(agentConfig2)};
+    createNodeAgent(connection2, {});
+    expect(agentkeepalive).to.have.been.calledWith({freeSocketTimeout: 3000});
+    expect(agentkeepalive.lastCall.args[0]).to.not.have.property('freeSocketKeepAliveTimeout');
   });
 
   it('correctly uses a logger, creates the LogConstructor and correctly formats trace information', () => {


### PR DESCRIPTION
## Summary

`elasticsearch@15.x`'s `makeAgentConfig()` returns an options object with `freeSocketKeepAliveTimeout`, which was renamed to `freeSocketTimeout` in `agentkeepalive@4.x`. This causes deprecation warnings at runtime.

`createNodeAgent` now remaps the option before passing to `AgentKeepAlive`, preserving any explicitly set `freeSocketTimeout` value.

## Test plan

- [x] `npm test` passes (6 tests, lint + 100% coverage)
- [x] Verify remap: `freeSocketKeepAliveTimeout` → `freeSocketTimeout`
- [x] Verify existing `freeSocketTimeout` is not overwritten